### PR TITLE
Playground Feature: Markdown READMEs - Milestone 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/submission/issue-18/milestone-3/TeamExponential/README.md
+++ b/submission/issue-18/milestone-3/TeamExponential/README.md
@@ -1,0 +1,9 @@
+# Playground Feature: Markdown READMEs - Milestone 4
+
+## Description
+
+This PR is for issue #18.
+
+We added support for storing and loading the README data on the backend and updating the GraphQL API. We followed the existing pattern and updated the storage, model and controller to include the new variables. We further added [sanitization](https://github.com/microcosm-cc/bluemonday) on save to make sure no untrusted data is stored. The tests were also updated to include tests for the newly introduced fields and sanitization. 
+
+Our code submission can be found here [#13](https://github.com/onflow/flow-playground-api/pull/13)


### PR DESCRIPTION
## Playground Feature: Markdown READMEs - Milestone 4

## Description
This PR is for issue #18.

We added support for storing and loading the README data on the backend and updating the GraphQL API. We followed the existing pattern and updated the storage, model and controller to include the new variables. We further added [sanitization](https://github.com/microcosm-cc/bluemonday) on save to make sure no untrusted data is stored. The tests were also updated to include tests for the newly introduced fields and sanitization. 

## Submission Links & Documents

- Our code submission can be found here [#13](https://github.com/onflow/flow-playground-api/pull/13)

## Requirements Check

- Have have you met the milestone requirements? Yes
- Have you included tests (if applicable)? N/A
- Have you met the contribution guidelines of the repos you have submitted code to (if applicable)? Yes
- If this is the last milestone:
  - Demonstrate that you've met all the acceptance criteria (link to code, demos, instructions to run etc.) Yes
  - Demonstrate that you've met all milestone requirements and highlight any extensions or additional work done. Yes
  - Include a payout structure by percentage for each team member (ie. Bob: 20%, Alice: 80%). @j00lz: 50%, @hichana 50%)